### PR TITLE
the corrected link works, but the returned xml has some missing impor…

### DIFF
--- a/lib/CXGN/Tools/FeatureFetch.pm
+++ b/lib/CXGN/Tools/FeatureFetch.pm
@@ -74,8 +74,8 @@ sub fetch {
 #http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=protein&id=8&rettype=gp&retmode=xml
 
 
-    my $feature_xml = `wget "eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=$GBaccession&rettype=xml&retmode=text"  -O -  `;
-    
+    my $feature_xml = `wget "eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=$GBaccession&rettype=text&retmode=xml"  -O -  `;
+  
     eval{ 
 	my $twig=XML::Twig->new(
 			    twig_roots   => 


### PR DESCRIPTION
…ted keys, such as the organism name. Troubleshooting with NCBI in progress

NCBI could not reproduce the problem. This morning the new XML did contain all the required information (specifically taxon ID and organism scientific name - <Org-ref_taxname>Solanum lycopersicum</Org-ref_taxname> )  

fixes https://github.com/solgenomics/sgn/issues/1508 

but still need better error messages when NCBI does not return the expected XML tags 