### PR TITLE
Brapi 1.3 images b base 15

### DIFF
--- a/lib/CXGN/Tag.pm
+++ b/lib/CXGN/Tag.pm
@@ -280,7 +280,7 @@ sub get_associated_image_ids {
                    FROM metadata.md_tag_image
                   WHERE tag_id=?";
     my $sth = $self->get_dbh()->prepare($query);
-    $sth -> execute($query);
+    $sth -> execute($self->get_tag_id());
     my @image_ids = ();
     while (my ($image_id) = $sth->fetchrow_array()) { 
 	push @image_ids, $image_id;


### PR DESCRIPTION
Allows for the image file of an image in the database to be updated, rather than creating a new image with a new image id. 

Change to the function in the Tags class was a bug fix where the sql query was used as a parameter in the sql query, rather than the tag id. 

These changes are not dependent on our changes in the sgn repo. But, our changes in the SGN rep are dependent on these changes. A pull request to merge our topic/brapi_auth branch into Mirella's brapi1.3 branch will be created today or tomorrow. After that, Mirella will merge brapi1.3 into master as we discussed last week. 