### PR TITLE
fix foreign key name in blast_db_blast_db_group table schema.

### DIFF
--- a/lib/SGN/Schema/BlastDbBlastDbGroup.pm
+++ b/lib/SGN/Schema/BlastDbBlastDbGroup.pm
@@ -18,7 +18,7 @@ __PACKAGE__->add_columns(
     },
     "blast_db_id",
     { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
-    "blast_db_blast_db_group_id",
+    "blast_db_group_id",
     { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
 
     );


### PR DESCRIPTION
For some odd reason, the primary key is listed as another foreign key, and the other foreign key is missing. This PR fixes that.